### PR TITLE
bug: Body field can be exported now

### DIFF
--- a/cmd/tcpListener/main.go
+++ b/cmd/tcpListener/main.go
@@ -33,6 +33,8 @@ func main() {
 		r.Headers.ForEach(func(n, v string) {
 			fmt.Printf("%s: %s\n", n, v)
 		})
+		fmt.Println("Body: ")
+		fmt.Printf("%s\n", r.Body)
 	}
 
 }

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -31,7 +31,7 @@ type RequestLine struct {
 type Request struct {
 	RequestLine RequestLine
 	Headers     *headers.Headers
-	body        string
+	Body        string
 	bodyBuffer  []byte
 	bodyPos     int
 	state       parsetState
@@ -118,7 +118,7 @@ outer:
 			read += remaining
 
 			if r.bodyPos == length {
-				r.body = string(r.bodyBuffer) // Single conversion at end
+				r.Body = string(r.bodyBuffer) // Single conversion at end
 				r.state = StateDone
 			}
 		case StateDone:

--- a/internal/request/request_test.go
+++ b/internal/request/request_test.go
@@ -111,7 +111,7 @@ func TestParseBody(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, r)
-	assert.Equal(t, "hello world!\n", string(r.body))
+	assert.Equal(t, "hello world!\n", string(r.Body))
 
 	// Test: Body shorter than reported content length
 	reader = &ChunkReader{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The TCP listener now includes the request body in its output. After headers, a “Body:” line is printed with the full payload.
  * The printed body reflects the complete request content once fully read.
  * No changes to commands, flags, or connection handling behavior.
  * Output formatting remains otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->